### PR TITLE
add optional --hours-back for edr monitor

### DIFF
--- a/elementary/monitor/api/alerts/alerts.py
+++ b/elementary/monitor/api/alerts/alerts.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from elementary.clients.api.api_client import APIClient
 from elementary.clients.dbt.dbt_runner import DbtRunner
@@ -24,13 +24,13 @@ class AlertsAPI(APIClient):
             config=self.config,
         )
 
-    def get_new_alerts(self, days_back: int) -> List[PendingAlertSchema]:
-        pending_alerts = self.alerts_fetcher.query_pending_alerts(days_back=days_back)
+    def get_new_alerts(self, days_back: int, hours_back: Optional[int] = None) -> List[PendingAlertSchema]:
+        pending_alerts = self.alerts_fetcher.query_pending_alerts(days_back=days_back, hours_back=hours_back)
         return pending_alerts
 
-    def get_alerts_last_sent_times(self, days_back: int) -> Dict[str, datetime]:
+    def get_alerts_last_sent_times(self, days_back: int, hours_back: Optional[int] = None) -> Dict[str, datetime]:
         alerts_last_sent_times = self.alerts_fetcher.query_last_alert_times(
-            days_back=days_back
+            days_back=days_back, hours_back=hours_back
         )
         last_sent_times = dict()
         for alert_class_id, last_sent_time_as_string in alerts_last_sent_times.items():

--- a/elementary/monitor/cli.py
+++ b/elementary/monitor/cli.py
@@ -93,6 +93,14 @@ def common_options(cmd: str):
             default=1 if cmd == Command.MONITOR else 7,
             help="Set a limit to how far back should edr collect data.",
         )(func)
+        if cmd in (Command.MONITOR):
+            func = click.option(
+                "--hours-back",
+                "-h",
+                type=int,
+                default=None,
+                help="Optionally set an hourly limit to how far back should edr collect data. If provided, it overrides --days-back.",
+            )(func)
         func = click.option(
             "--env",
             type=str,
@@ -166,6 +174,7 @@ def get_cli_properties() -> dict:
     full_refresh_dbt_package = params.get("full_refresh_dbt_package")
     select = params.get("select")
     days_back = params.get("days_back")
+    hours_back = params.get("hours_back")
     timezone = params.get("timezone")
     group_by = params.get("group_by")
     suppression_interval = params.get("suppression_interval")
@@ -177,6 +186,7 @@ def get_cli_properties() -> dict:
         "full_refresh_dbt_package": full_refresh_dbt_package,
         "select": select,
         "days_back": days_back,
+        "hours_back": hours_back,
         "timezone": timezone,
         "group_by": group_by,
         "suppression_interval": suppression_interval,
@@ -272,6 +282,7 @@ def get_cli_properties() -> dict:
 def monitor(
     ctx,
     days_back,
+    hours_back,
     slack_webhook,
     deprecated_slack_webhook,
     slack_token,
@@ -362,7 +373,7 @@ def monitor(
             Command.MONITOR, get_cli_properties(), ctx.command.name
         )
         success = data_monitoring.run_alerts(
-            days_back, full_refresh_dbt_package, dbt_vars=vars
+            days_back, hours_back, full_refresh_dbt_package, dbt_vars=vars
         )
         anonymous_tracking.track_cli_end(
             Command.MONITOR, data_monitoring.properties(), ctx.command.name

--- a/elementary/monitor/dbt_project/macros/get_alerts_time_limit_hour.sql
+++ b/elementary/monitor/dbt_project/macros/get_alerts_time_limit_hour.sql
@@ -1,0 +1,5 @@
+{% macro get_alerts_time_limit_hour(hours_back=24) %}
+    {% set nowtime = elementary.edr_current_timestamp() %}
+	{% set datetime_limit = elementary.edr_timeadd('hour', hours_back * -1, nowtime) %}
+    {{ return(datetime_limit) }}
+{% endmacro %}

--- a/elementary/monitor/dbt_project/packages.yml
+++ b/elementary/monitor/dbt_project/packages.yml
@@ -1,6 +1,6 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: [">=0.8.0", "<0.9.0"]
+    version: [">=1.0.0", "<2.0.0"]
   - package: elementary-data/elementary
     version: 0.15.1
 

--- a/elementary/monitor/dbt_project/packages.yml
+++ b/elementary/monitor/dbt_project/packages.yml
@@ -1,8 +1,8 @@
 packages:
   - package: dbt-labs/dbt_utils
     version: [">=0.8.0", "<2.0.0"]
-  # - package: elementary-data/elementary
-  #   version: 0.15.1
+  - package: elementary-data/elementary
+    version: 0.15.1
 
   #  NOTE - for unreleased CLI versions we often need to update the package version to a commit hash (please leave this
   #  commented, so it will be easy to access)

--- a/elementary/monitor/dbt_project/packages.yml
+++ b/elementary/monitor/dbt_project/packages.yml
@@ -1,8 +1,8 @@
 packages:
   - package: dbt-labs/dbt_utils
     version: [">=0.8.0", "<2.0.0"]
-  - package: elementary-data/elementary
-    version: 0.15.1
+  # - package: elementary-data/elementary
+  #   version: 0.15.1
 
   #  NOTE - for unreleased CLI versions we often need to update the package version to a commit hash (please leave this
   #  commented, so it will be easy to access)

--- a/elementary/monitor/dbt_project/packages.yml
+++ b/elementary/monitor/dbt_project/packages.yml
@@ -1,6 +1,6 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: [">=0.8.0", "<2.0.0"]
+    version: [">=1.0.0", "<2.0.0"]
   - package: elementary-data/elementary
     version: 0.15.1
 

--- a/elementary/monitor/dbt_project/packages.yml
+++ b/elementary/monitor/dbt_project/packages.yml
@@ -1,6 +1,6 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: [">=0.8.0", "<0.9.0"]
+    version: [">=0.8.0", "<2.0.0"]
   - package: elementary-data/elementary
     version: 0.15.1
 

--- a/elementary/monitor/dbt_project/packages.yml
+++ b/elementary/monitor/dbt_project/packages.yml
@@ -1,6 +1,6 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: [">=1.0.0", "<2.0.0"]
+    version: [">=0.8.0", "<0.9.0"]
   - package: elementary-data/elementary
     version: 0.15.1
 

--- a/elementary/monitor/fetchers/alerts/alerts.py
+++ b/elementary/monitor/fetchers/alerts/alerts.py
@@ -38,11 +38,11 @@ class AlertsFetcher(FetcherClient):
             )
 
     def query_pending_alerts(
-        self, days_back: int, type: Optional[AlertTypes] = None
+        self, days_back: int, type: Optional[AlertTypes] = None, hours_back: Optional[int] = None
     ) -> List[PendingAlertSchema]:
         pending_alerts_results = self.dbt_runner.run_operation(
             macro_name="elementary_cli.get_pending_alerts",
-            macro_args={"days_back": days_back, "type": type.value if type else None},
+            macro_args={"days_back": days_back, "type": type.value if type else None, "hours_back": hours_back},
         )
         return [
             PendingAlertSchema(**result)
@@ -50,11 +50,11 @@ class AlertsFetcher(FetcherClient):
         ]
 
     def query_last_alert_times(
-        self, days_back: int, type: Optional[AlertTypes] = None
+        self, days_back: int, type: Optional[AlertTypes] = None, hours_back: Optional[int] = None
     ) -> Dict[str, str]:
         response = self.dbt_runner.run_operation(
             macro_name="elementary_cli.get_last_alert_sent_times",
-            macro_args={"days_back": days_back, "type": type.value if type else None},
+            macro_args={"days_back": days_back, "type": type.value if type else None, "hours_back": hours_back},
         )
         return json.loads(response[0])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "elementary-data"
-version = "0.15.1"
+version = "0.15.1-rv.1"
 description = "Data monitoring and lineage"
 authors = ["Elementary"]
 keywords = ["data", "lineage", "data lineage", "data warehouse", "DWH", "observability", "data monitoring", "data observability", "Snowflake", "BigQuery", "Redshift", "data reliability", "analytics engineering"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "elementary-data"
-version = "0.15.1-rv.1"
+version = "0.15.1+rv10"
 description = "Data monitoring and lineage"
 authors = ["Elementary"]
 keywords = ["data", "lineage", "data lineage", "data warehouse", "DWH", "observability", "data monitoring", "data observability", "Snowflake", "BigQuery", "Redshift", "data reliability", "analytics engineering"]


### PR DESCRIPTION
Add optional `--hours-back` for `edr monitor` to specify how many hours back should `edr monitor` look for pending alerts.